### PR TITLE
Update docker usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -190,8 +190,7 @@ install.py will keep the old config.json and nginx.conf during update. So that y
 After cloning code to your local filesystem, you can run the following commands:
 
 ```
-cd Docker  
-docker build -t verynginx .
+docker build -t verynginx -f Docker/Dockerfile .
 docker run verynginx
 ```
 


### PR DESCRIPTION
If run build command inside `/Docker` folder, it will cause an error says that can't open file `install.py`, so I recommend to build docker image in the root path of the repo and specify the `Dockerfile` path.